### PR TITLE
Fix requests with german culture

### DIFF
--- a/src/Mockaroo.Core/Fields/DateField.cs
+++ b/src/Mockaroo.Core/Fields/DateField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Gigobyte.Mockaroo.Fields
 {
@@ -23,7 +24,7 @@ namespace Gigobyte.Mockaroo.Fields
         public override string ToJson()
         {
             string firstHalf = base.ToJson().TrimEnd('}');
-            return $"{firstHalf},\"min\":\"{Min.Date.ToString(Mockaroo.DateFormat)}\",\"max\":\"{Max.ToString(Mockaroo.DateFormat)}\"}}";
+            return $"{firstHalf},\"min\":\"{Min.Date.ToString(Mockaroo.DateFormat, CultureInfo.InvariantCulture)}\",\"max\":\"{Max.ToString(Mockaroo.DateFormat, CultureInfo.InvariantCulture)}\"}}";
         }
     }
 }

--- a/src/Mockaroo.Core/Fields/SQLExpressionField.cs
+++ b/src/Mockaroo.Core/Fields/SQLExpressionField.cs
@@ -1,0 +1,20 @@
+﻿namespace Gigobyte.Mockaroo.Fields
+{
+    public partial class SQLExpressionField
+    {
+        /// <summary>
+        /// Gets or sets the sql expression.
+        /// </summary>
+        /// <value>The sql expression.</value>
+        public string Value { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Converts this instance into its equivalent json representation.
+        /// </summary>
+        /// <returns>A json representation of the instance.</returns>
+        public override string ToJson()
+        {
+            return $"{BaseJson()},\"value\":\"{Value}\"}}";
+        }
+    }
+}

--- a/src/Mockaroo.Core/Mockaroo.Core.csproj
+++ b/src/Mockaroo.Core/Mockaroo.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Fields\JSONArrayField.cs" />
     <Compile Include="Fields\NumberField.cs" />
     <Compile Include="Arrangement.cs" />
+    <Compile Include="Fields\SQLExpressionField.cs" />
     <Compile Include="Fields\WordsField.cs" />
     <Compile Include="Mockaroo.cs" />
     <Compile Include="MockarooClient.cs" />

--- a/src/Mockaroo.Core/Serialization/ClrDataAdapter.cs
+++ b/src/Mockaroo.Core/Serialization/ClrDataAdapter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Globalization;
 
 namespace Gigobyte.Mockaroo.Serialization
 {
@@ -86,7 +87,7 @@ namespace Gigobyte.Mockaroo.Serialization
                         case BuildPath.Basic:
                             propertyValue = property.PropertyType.GetTypeInfo().IsEnum ?
                                 propertyValue = Enum.Parse(property.PropertyType, json[property.Name].Value<string>()) :
-                                propertyValue = Convert.ChangeType(json[property.Name].Value<string>(), property.PropertyType);
+                                propertyValue = Convert.ChangeType(json[property.Name].Value<string>(), property.PropertyType, CultureInfo.InvariantCulture);
 
                             property.SetValue(instance, propertyValue);
                             break;


### PR DESCRIPTION
The date fields where send in the wrong format, if the application runs with german culture.

Also fixed the SQLExpressionField. Added the value property to the request.
